### PR TITLE
Support for parsing files with the custom functions defined in the variable details sheet

### DIFF
--- a/R/strings.R
+++ b/R/strings.R
@@ -29,6 +29,8 @@ pkg.env$node_name.interval <- "Interval"
 pkg.env$node_name.derived_field <- "DerivedField"
 pkg.env$node_name.apply <- "Apply"
 pkg.env$node_name.field_ref <- "FieldRef"
+pkg.env$node_name.local_transformations <- "LocalTransformations"
+pkg.env$node_name.define_function <- "DefineFunction"
 
 pkg.env$node_namespace.pmml <- "http://www.dmg.org/PMML-4_4"
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Currently `recodeflow` is used in packages that harmonize health surveys and hea
 
 - `raiflow` is a package that will harmonize variables within the Resident Assessments Instruments (RAI) from various sources: Canada's Continuing Care Reporting System (CCRS) and Ontario's Resident Assessment Instrutment for Home Care (RAI-HC). `raiflow` is currently underdevelopment.
 
+# Requirements
+
+* If you plan on using the `recode_to_pmml` function's `custom_function_files` argument, you need access to the `local-transformations-generator` repo
+
 # Roadmap
 
 Projects on the roadmap are at the Github repository recodeflow under the [projects tab](https://github.com/Big-Life-Lab/recodeflow/projects).

--- a/assets/tests/integration/custom-functions-1.R
+++ b/assets/tests/integration/custom-functions-1.R
@@ -1,0 +1,7 @@
+custom_function_one <- function(a) {
+  return(a)
+}
+
+custom_function_two <- function(b) {
+  return(b)
+}

--- a/assets/tests/integration/custom-functions-2.R
+++ b/assets/tests/integration/custom-functions-2.R
@@ -1,0 +1,3 @@
+custom_function_three <- function(c) {
+  return(c)
+}

--- a/assets/tests/integration/expected-pmml.xml
+++ b/assets/tests/integration/expected-pmml.xml
@@ -299,5 +299,17 @@
     <Extension name="catLabelLong" value="missing"/>
    </Value>
   </DerivedField>
+  <DefineFunction name="custom_function_one">
+   <ParameterField name="a" dataType="double"/>
+   <FieldRef field="a"/>
+  </DefineFunction>
+  <DefineFunction name="custom_function_two">
+   <ParameterField name="b" dataType="double"/>
+   <FieldRef field="b"/>
+  </DefineFunction>
+  <DefineFunction name="custom_function_three">
+   <ParameterField name="c" dataType="double"/>
+   <FieldRef field="c"/>
+  </DefineFunction>
  </TransformationDictionary>
 </PMML>

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -20,7 +20,10 @@ test_that("The PMML file is correctly generated", {
     var_details_sheet,
     vars_sheet,
     db_name,
-    vars
+    vars,
+    custom_function_files = c(
+      "../../assets/tests/integration/custom-functions-1.R",
+      "../../assets/tests/integration/custom-functions-2.R")
   )
 
   actual_pmml_string <- XML::toString.XMLNode(actual_pmml)


### PR DESCRIPTION
Adds a new argument called `custom_function_files` to the `recode_to_pmml` function. We need this for converting the DemPoRT algorithm to PMML.