### PR TITLE
Added test case for a bug where recoding a non-derived variable with a derived variable results in an infinite loop

### DIFF
--- a/assets/tests/integration/rec-with-table/custom-functions.R
+++ b/assets/tests/integration/rec-with-table/custom-functions.R
@@ -1,0 +1,3 @@
+var_two_fun <- function(var_one) {
+  return(var_one)
+}

--- a/assets/tests/integration/rec-with-table/variable-details-sheet.csv
+++ b/assets/tests/integration/rec-with-table/variable-details-sheet.csv
@@ -1,0 +1,4 @@
+variable,dummyVariable,typeEnd,databaseStart,variableStart,typeStart,recEnd,numValidCat,catLabel,catLabelLong,units,recStart,catStartLabel,variableStartShortLabel,variableStartLabel,notes
+var_one,,cat,db_one,[var_one_start],cat,copy,2,,,,else,,,,
+var_two,,cat,db_one,DerivedVar::[var_one],cat,Func::var_two_func,2,,,,N/A,,,,
+var_three,,cat,db_one,[var_two],cat,copy,2,,,,else,,,,

--- a/assets/tests/integration/rec-with-table/variables-sheet.csv
+++ b/assets/tests/integration/rec-with-table/variables-sheet.csv
@@ -1,0 +1,4 @@
+﻿variable,role,label,labelLong,section,subject,variableType,units,databaseStart,variableStart,description
+var_one,,Variable One,Variable One,,,cat,,db_one,[var_one_start],
+var_two,,Variable Two,Variable Two,,,cat,,db_one,DerivedVar::[var_one],
+var_three,,Variable Three,Variable Three,,,cat,,db_one,[var_two],

--- a/tests/testthat/test-rec-with-table.R
+++ b/tests/testthat/test-rec-with-table.R
@@ -1,0 +1,32 @@
+context("Integration Tests")
+
+test_that("Normal variables that depend on derived variables are properly recoded", {
+  data <- data.frame(
+    var_one_start = c(1, 2, 3)
+  )
+
+  variables_sheet <- read.csv(
+    file.path("../../assets/tests/integration/rec-with-table/variables-sheet.csv"),
+    fileEncoding = "UTF-8-BOM")
+
+  variable_details_sheet <- read.csv(
+    file.path(getwd(), "../../assets/tests/integration/rec-with-table/variable-details-sheet.csv"),
+    fileEncoding = "UTF-8-BOM")
+
+  print("check")
+  recoded_data <- recodeflow::rec_with_table(
+    data,
+    database_name = "db_one",
+    variables = variables_sheet,
+    variable_details = variable_details_sheet,
+    custom_function_path = file.path(getwd(), "../../assets/tests/integration/rec-with-table/custom-functions.R")
+  )
+
+  print("inside")
+  expected_recoded_data <- data.frame(
+    var_one = data$var_one_start,
+    var_two = data$var_one_start,
+    var_three = data$var_one_start
+  )
+  expect_equal(recoded_data, expected_recoded_data)
+})


### PR DESCRIPTION
The test case is in the `test-rec-with-table.R` file. 

Run the command `devtools::test(filter = "rec-with-table")` to run the test.

All the sheets for this test are in `assets/tests/integration/rec-with-table`

Variable Involved

* `var_two` is the derived variable that depends on `var_one`
* `var_three` is the non-derived variable that depends on `var_two`