### PR TITLE
Constant derived start variables

### DIFF
--- a/R/recode-with-table.R
+++ b/R/recode-with-table.R
@@ -1250,7 +1250,7 @@ recode_derived_variables <-
         custom_function_args <- list()
         for(feeder_var in used_feeder_vars) {
           if(is_table_feeder_var(feeder_var)) {
-            table_name <- get_table_name(feeder_vars)
+            table_name <- get_table_name(feeder_var)
             custom_function_args[[table_name]] <- tables[[table_name]]
           } else {
             if(feeder_var %in% names(recoded_data)) {

--- a/R/recode-with-table.R
+++ b/R/recode-with-table.R
@@ -1164,7 +1164,9 @@ recode_derived_variables <-
           variables_details_rows_to_process[
             variables_details_rows_to_process[[pkg.env$columns.variable]] == feeder_var, ])
         ) {
-          if(!feeder_var %in% c(names(recoded_data), names(data))) {
+          if(!feeder_var %in% c(names(data), names(recoded_data)) &
+             !is_start_var_string(feeder_var) &
+             !is_start_var_numeric(feeder_var)) {
             non_func_missing_variables <- c(non_func_missing_variables, feeder_var)
           }
         }
@@ -1212,7 +1214,9 @@ recode_derived_variables <-
       for (one_feeder in feeder_vars) {
         if(!is_table_feeder_var(one_feeder)) {
           # Need to check recoded data again in case a recursion added it
-          if (!one_feeder %in% c(names(data), names(recoded_data))) {
+          if (!one_feeder %in% c(names(data), names(recoded_data)) &
+             !is_start_var_string(one_feeder) &
+             !is_start_var_numeric(one_feeder)) {
             derived_return <-
               recode_derived_variables(
                 data = data,
@@ -1256,8 +1260,17 @@ recode_derived_variables <-
             if(feeder_var %in% names(recoded_data)) {
               custom_function_args[[feeder_var]] <- recoded_data[recoded_data_row_index, feeder_var]
             }
-            else {
+            else if(feeder_var %in% names(data)) {
               custom_function_args[[feeder_var]] <- data[recoded_data_row_index, feeder_var]
+            }
+            else if(is_start_var_string(feeder_var)) {
+              string_constant_match <- stringr::str_match(
+                feeder_var, str_constant_regex)
+              string_constant <- string_constant_match[1, 2]
+              custom_function_args[[feeder_var]] <- string_constant
+            }
+            else {
+              custom_function_args[[feeder_var]] <- as.numeric(feeder_var)
             }
           }
         }
@@ -1371,3 +1384,23 @@ is_derived_var <- function(variable_details_row) {
     derived_var_regex, variable_details_row[1, pkg.env$columns.variableStart]
   )) > 0)
 }
+
+#' Check whether a start variable is a numeric constant
+#'
+#' @param x the string to be checked
+#' @returns boolean
+is_start_var_numeric <- function(x) {
+  return(!is.na(suppressWarnings(as.numeric(x))))
+}
+
+# Regex to check for a string constant
+str_constant_regex <- "(?:'|\")(.+)(?:'|\")"
+
+#' Checks whether a start variable is a string constant
+#'
+#' @param x the string to be checked
+#' @returns boolean
+is_start_var_string <- function(x) {
+  return(grepl(str_constant_regex, x))
+} 
+

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -1,0 +1,12 @@
+#' Does the setup and cleanup for a custom function to be used in a
+#' rec_with_table test
+#'
+#' @param custom_function the custom function
+#' @param env the environment in which the test is executed. You should not
+#' need to set this.
+#' @returns NULL
+setup_custom_function <- function(custom_function, env = parent.frame()) {
+  original_name <- deparse(substitute(custom_function))
+  .GlobalEnv[[original_name]] <- custom_function 
+  withr::defer(rm(list = original_name, envir = .GlobalEnv), env = env)
+}

--- a/tests/testthat/test-recode-with-table.R
+++ b/tests/testthat/test-recode-with-table.R
@@ -125,14 +125,14 @@ test_that("Tables work with custom functions", {
     units = c("N/A", "N/A"),
     variableType = c("Continuous", "Continuous"),
     databaseStart = c("database_one", "database_one"),
-    variableStart = c("[start_var]", "DerivedVar::[derived_variable_one, tables::table_one]")
+    variableStart = c("[start_var]", "DerivedVar::[derived_variable_one, tables::table_one, tables::table_two]")
   )
   database_name <- "database_one"
   variable_details <- data.frame(
     variable = c("derived_variable_one", "derived_variable_two"),
     typeEnd = c("cont", "cont"),
     databaseStart = c("database_one", "database_one"),
-    variableStart = c("[start_var]", "DerivedVar::[derived_variable_one, tables::table_one]"),
+    variableStart = c("[start_var]", "DerivedVar::[derived_variable_one, tables::table_one, tables::table_two]"),
     typeStart = c("N/A", "N/A"),
     recEnd = c("copy", "Func::func_1"),
     numValidCategories = c("N/A", "N/A"),
@@ -144,10 +144,11 @@ test_that("Tables work with custom functions", {
     table_one = data.frame(
       derived_variable_one = c(1),
       derived_variable_two = c(2)
-    )
+    ),
+    table_two = data.frame()
   )
   # Custom function for the derived variable
-  func_1 <- function(derived_variable_one, table_one) {
+  func_1 <- function(derived_variable_one, table_one, table_two) {
     return(table_one[table_one$derived_variable_one == derived_variable_one,]$derived_variable_two)
   }
   .GlobalEnv[["func_1"]] <- func_1

--- a/tests/testthat/test-recode-with-table.R
+++ b/tests/testthat/test-recode-with-table.R
@@ -30,11 +30,11 @@ test_that("When the start variable is a derived variable, it should correctly re
     catLabel = c("", "", ""),
     catLabelLong = c("", "", "")
   )
-  # Custom function for the derived variable
+
   derived_variable <- function(non_derived_variable_one) {
     return(non_derived_variable_one)
   }
-  .GlobalEnv[["derived_variable"]] <- derived_variable
+  setup_custom_function(derived_variable)
 
   actual_output <- rec_with_table(
     data = data,
@@ -54,8 +54,6 @@ test_that("When the start variable is a derived variable, it should correctly re
   attr(expected_output$non_derived_variable_two, "label_long") <- ""
 
   expect_equal(actual_output, expected_output)
-
-  on.exit(rm("derived_variable", envir = .GlobalEnv))
 })
 
 test_that("When the start variable is a derived variable, it should Should correctly recode when the derived variable is categorical", {
@@ -81,11 +79,12 @@ test_that("When the start variable is a derived variable, it should Should corre
     catLabel = c("", "", "", ""),
     catLabelLong = c("", "", "", "")
   )
-  # Custom function for the derived variable
+
   derived_variable <- function(non_derived_variable_one) {
     return(1)
   }
-  .GlobalEnv[["derived_variable"]] <- derived_variable
+  setup_custom_function(derived_variable)
+
   data <- data.frame(
     start_variable_one = c(1)
   )
@@ -110,8 +109,6 @@ test_that("When the start variable is a derived variable, it should Should corre
   )
 
   expect_equal(actual_output, expected_output)
-
-  on.exit(rm("derived_variable", envir = .GlobalEnv))
 })
 
 test_that("Tables work with custom functions", {
@@ -147,11 +144,11 @@ test_that("Tables work with custom functions", {
     ),
     table_two = data.frame()
   )
-  # Custom function for the derived variable
+
   func_1 <- function(derived_variable_one, table_one, table_two) {
     return(table_one[table_one$derived_variable_one == derived_variable_one,]$derived_variable_two)
   }
-  .GlobalEnv[["func_1"]] <- func_1
+  setup_custom_function(func_1)
 
   actual_output <- rec_with_table(
     data = data,
@@ -169,8 +166,6 @@ test_that("Tables work with custom functions", {
   attr(expected_output$derived_variable_one, "label_long") <- ""
 
   expect_equal(actual_output, expected_output)
-
-  on.exit(rm("func_1", envir = .GlobalEnv))
 })
 
 test_that("Recode correctly when the start variable for a database is a derived variable", {
@@ -200,11 +195,11 @@ test_that("Recode correctly when the start variable for a database is a derived 
   )
   database_name <- "database_one"
   tables <- list()
-  # Custom function for the derived variable
+
   func_1 <- function(variable) {
     return(variable)
   }
-  .GlobalEnv[["func_1"]] <- func_1
+  setup_custom_function(func_1)
 
   actual_output <- rec_with_table(
     data = data,
@@ -224,8 +219,6 @@ test_that("Recode correctly when the start variable for a database is a derived 
   attr(expected_output$variable_one, "label_long") <- NA_character_
 
   expect_equal(actual_output, expected_output)
-
-  on.exit(rm("func_1", envir = .GlobalEnv))
 })
 
 test_that("Recode correctly when the start variable for a database is the default derived variable", {
@@ -255,11 +248,11 @@ test_that("Recode correctly when the start variable for a database is the defaul
   )
   database_name <- "database_two"
   tables <- list()
-  # Custom function for the derived variable
+
   func_1 <- function(variable_one) {
     return(1)
   }
-  .GlobalEnv[["func_1"]] <- func_1
+  setup_custom_function(func_1)
 
   actual_output <- rec_with_table(
     data = data,
@@ -279,8 +272,6 @@ test_that("Recode correctly when the start variable for a database is the defaul
   attr(expected_output$variable_two, "label_long") <- NA_character_
 
   expect_equal(actual_output, expected_output)
-
-  on.exit(rm("func_1", envir = .GlobalEnv))
 })
 
 test_that("Correctly recodes when the start variable has only one derived var", {
@@ -310,11 +301,11 @@ test_that("Correctly recodes when the start variable has only one derived var", 
   )
   database_name <- "database_one"
   tables <- list()
-  # Custom function for the derived variable
+
   func_1 <- function(variable_one) {
     return(1)
   }
-  .GlobalEnv[["func_1"]] <- func_1
+  setup_custom_function(func_1)
 
   actual_output <- rec_with_table(
     data = data,
@@ -334,8 +325,6 @@ test_that("Correctly recodes when the start variable has only one derived var", 
   attr(expected_output$variable_one, "label_long") <- NA_character_
 
   expect_equal(actual_output, expected_output)
-
-  on.exit(rm("func_1", envir = .GlobalEnv))
 })
 
 test_that("Should pass in the function arguments one at a time", {
@@ -365,14 +354,14 @@ test_that("Should pass in the function arguments one at a time", {
   )
   database_name <- "database_one"
   tables <- list()
-  # Custom function for the derived variable
+
   func_1 <- function(variable_one) {
     if(length(variable_one) > 1) {
       return(2)
     }
     return(1)
   }
-  .GlobalEnv[["func_1"]] <- func_1
+  setup_custom_function(func_1)
 
   expected_output <- data.frame(
     start_variable_one = c(1, 2),
@@ -391,8 +380,6 @@ test_that("Should pass in the function arguments one at a time", {
     append_to_data = TRUE
   )
   expect_equal(actual_output, expected_output)
-
-  on.exit(rm("func_1", envir = .GlobalEnv))
 })
 
 test_that("When a variable has a start variable that is not in the variables argument but is in the data, it should continue to recode the variable", {
@@ -423,11 +410,11 @@ test_that("When a variable has a start variable that is not in the variables arg
     catLabelLong = c("", "", "")
   )
   tables <- list()
-  # Custom function for the derived variable
+
   func_1 <- function(variable_one) {
     return(variable_one)
   }
-  .GlobalEnv[["func_1"]] <- func_1
+  setup_custom_function(func_1)
 
   actual_output <- recodeflow::rec_with_table(
     data = data,
@@ -448,8 +435,6 @@ test_that("When a variable has a start variable that is not in the variables arg
   attr(expected_output$variable_two, "label_long") <- NA_character_
 
   expect_equal(actual_output, expected_output)
-
-  on.exit(rm("func_1", envir = .GlobalEnv))
 })
 
 test_that("Correctly recodes derived variable that depends on a derived variable even when the variables argument and variables sheet have them in the wrong order i.e. the dependant variables comes before", {
@@ -479,15 +464,15 @@ test_that("Correctly recodes derived variable that depends on a derived variable
   )
   database_name <- "database_one"
   tables <- list()
-  # Custom function for the derived variable
+
   func_1 <- function(variable_one) {
     return(1)
   }
+  setup_custom_function(func_1)
   func_2 <- function(variable_one) {
     return(2)
   }
-  .GlobalEnv[["func_1"]] <- func_1
-  .GlobalEnv[["func_2"]] <- func_2
+  setup_custom_function(func_2)
 
   actual_output <- recodeflow::rec_with_table(
     data = data,
@@ -508,9 +493,6 @@ test_that("Correctly recodes derived variable that depends on a derived variable
   attr(expected_output$variable_one, "label_long") <- NA_character_
 
   expect_equal(actual_output, expected_output)
-
-  on.exit(rm("func_1", envir = .GlobalEnv))
-  on.exit(rm("func_2", envir = .GlobalEnv))
 })
 
 test_that("The function should not error when a tibble is passed in", {

--- a/tests/testthat/test-recode-with-table.R
+++ b/tests/testthat/test-recode-with-table.R
@@ -546,3 +546,166 @@ test_that("The function should not error when a tibble is passed in", {
   attr(expected_data$b, "unit") <- "N/A"
   expect_equal(recoded_data, expected_data)
 })
+
+test_that(
+  "derived variables work with constant numeric values as a dependency",
+  {
+    variables <- data.frame(
+      variable = c(
+        "num_hours_jogging",
+        "num_hours_basketball",
+        "mets_jogging",
+        "mets_basketball"
+      ),
+      label = c("", "", "", ""),
+      labelLong = c("", "", "", ""),
+      units = c("N/A", "N/A", "N/A", "N/A"),
+      variableType = c("Continuous", "Continuous", "Continuous", "Continuous"),
+      databaseStart = c("db_one", "db_one", "db_one", "db_one"),
+      variableStart = c(
+        "[num_hours_jogging]",
+        "[num_hours_basketball]",
+        "DerivedVar::[num_hours_jogging, 7]",
+        "DerivedVar::[num_hours_basketball, 6.5]"
+      )
+    )
+    variable_details <- data.frame(
+      variable = c(
+        "num_hours_jogging",
+        "num_hours_basketball",
+        "mets_jogging",
+        "mets_basketball"
+      ),
+      typeEnd = c("cont", "cont", "cont", "cont"),
+      databaseStart = c("db_one", "db_one", "db_one", "db_one"),
+      variableStart = c(
+        "[num_hours_jogging]",
+        "[num_hours_basketball]",
+        "DerivedVar::[num_hours_jogging, 7]",
+        "DerivedVar::[num_hours_basketball, 6.5]"
+      ),
+      typeStart = c("cont", "cont", "cont", "cont"),
+      recEnd = c("copy", "copy", "Func::get_mets", "Func::get_mets"),
+      numValidCategories = c("N/A", "N/A", "N/A", "N/A"),
+      recStart = c("else", "else", "N/A", "N/A"),
+      catLabel = c("", "", "", ""),
+      catLabelLong = c("", "", "", "")
+    )
+    data <- data.frame(
+      num_hours_jogging = c(2),
+      num_hours_basketball = c(5)
+    )
+    database_name <- "db_one"
+    tables <- list()
+    get_mets <- function(num_hours_activity, activity_met_value) {
+      return(num_hours_activity * activity_met_value)
+    }
+    setup_custom_function(get_mets)
+
+    actual_output <- recodeflow::rec_with_table(
+      data = data,
+      variables = variables$variable,
+      variable_details = variable_details,
+      database_name = database_name,
+      tables = tables
+    )
+
+    expected_output <- data.frame(
+      num_hours_jogging = c(2),
+      num_hours_basketball = c(5),
+      mets_jogging = c(14),
+      mets_basketball = c(32.5)
+    )
+    attr(expected_output$num_hours_jogging, "label_long") <- NA_character_
+    attr(expected_output$num_hours_jogging, "unit") <- character(0)
+    attr(expected_output$num_hours_basketball, "label_long") <- NA_character_
+    attr(expected_output$num_hours_basketball, "unit") <- character(0)
+
+    expect_equal(actual_output, expected_output)
+  }
+)
+
+test_that(
+  "derived variables work with constant string values as a dependency",
+  {
+    variables <- data.frame(
+      variable = c(
+        "num_hours_jogging",
+        "num_hours_basketball",
+        "mets_jogging",
+        "mets_basketball"
+      ),
+      label = c("", "", "", ""),
+      labelLong = c("", "", "", ""),
+      units = c("N/A", "N/A", "N/A", "N/A"),
+      variableType = c("Continuous", "Continuous", "Continuous", "Continuous"),
+      databaseStart = c("db_one", "db_one", "db_one", "db_one"),
+      variableStart = c(
+        "[num_hours_jogging]",
+        "[num_hours_basketball]",
+        "DerivedVar::[num_hours_jogging, 'jogging', tables::mets_map]",
+        "DerivedVar::[num_hours_basketball, \"basketball\", tables::mets_map]"
+      )
+    )
+    variable_details <- data.frame(
+      variable = c(
+        "num_hours_jogging",
+        "num_hours_basketball",
+        "mets_jogging",
+        "mets_basketball"
+      ),
+      typeEnd = c("cont", "cont", "cont", "cont"),
+      databaseStart = c("db_one", "db_one", "db_one", "db_one"),
+      variableStart = c(
+        "[num_hours_jogging]",
+        "[num_hours_basketball]",
+        "DerivedVar::[num_hours_jogging, 'jogging', tables::mets_map]",
+        "DerivedVar::[num_hours_basketball, \"basketball\", tables::mets_map]"
+      ),
+      typeStart = c("cont", "cont", "cont", "cont"),
+      recEnd = c("copy", "copy", "Func::get_mets", "Func::get_mets"),
+      numValidCategories = c("N/A", "N/A", "N/A", "N/A"),
+      recStart = c("else", "else", "N/A", "N/A"),
+      catLabel = c("", "", "", ""),
+      catLabelLong = c("", "", "", "")
+    )
+    data <- data.frame(
+      num_hours_jogging = c(2),
+      num_hours_basketball = c(5)
+    )
+    database_name <- "db_one"
+    tables <- list(
+      mets_map = data.frame(
+        activity = c("jogging", "basketball"),
+        mets = c(7, 6.5)
+      )
+    )
+    # Custom function for the derived variable
+    get_mets <- function(num_hours_activity, activity_type, mets_map) {
+      activity_met_value <- mets_map[mets_map$activity == activity_type, ]
+      return(num_hours_activity * activity_met_value$mets)
+    }
+    setup_custom_function(get_mets)
+
+    actual_output <- recodeflow::rec_with_table(
+      data = data,
+      variables = variables$variable,
+      variable_details = variable_details,
+      database_name = database_name,
+      tables = tables
+    )
+
+    expected_output <- data.frame(
+      num_hours_jogging = c(2),
+      num_hours_basketball = c(5),
+      mets_jogging = c(14),
+      mets_basketball = c(32.5)
+    )
+    attr(expected_output$num_hours_jogging, "label_long") <- NA_character_
+    attr(expected_output$num_hours_jogging, "unit") <- character(0)
+    attr(expected_output$num_hours_basketball, "label_long") <- NA_character_
+    attr(expected_output$num_hours_basketball, "unit") <- character(0)
+
+    expect_equal(actual_output, expected_output)
+  }
+)

--- a/vignettes/derived_variables.Rmd
+++ b/vignettes/derived_variables.Rmd
@@ -86,3 +86,74 @@ derived1 <- rec_with_table(
 print(head(derived1))
 ```
 
+## Start Variables
+
+In the example above the derived start variables were all variables themselves.
+However, the start variables strings for example 'en' or numbers for example 5.
+Strings should be surrounded by quotes, either single quotes (') or double
+quotes (").
+
+For example, consider the R function below that calculates BMI and truncates
+it so that its value cannot be higher than the `upper_bound` parameter.
+
+```{r}
+BMI.func <- function(height, weight, upper_bound) {
+  bmi <- weight / (height * height)
+
+  if(bmi > upper_bound) {
+    return(upper_bound)
+  }
+
+  return(bmi)
+}
+```
+
+The variable details sheet row for this variable is shown below,
+
+```{r}
+variable_details_sheet <- data.frame(
+  variable = c("BMI", "height", "weight"),
+  variableStart = c(
+   "DerivedVar::[height, weight, 35]", "[height]", "[weight]"
+  ),
+  recEnd = c("Func::BMI.func", "copy", "copy"),
+  typeEnd = c("cont", "cont", "cont"),
+  typeStart = c("cont", "cont", "cont"),
+  databaseStart = c("health", "health", "health"),
+  variableStartLabel = c("N/A", "height", "weight"),
+  numValidCate = c("N/A", "N/A", "N/A"),
+  catLabel = c("N/A", "N/A", "N/A"),
+  catLabelLong = c("N/A", "N/A", "N/A"),
+  units = c("kg/cm^2", "cm", "kg"),
+  recStart = c("N/A", "else", "else"),
+  catStartLabel = c("N/A", "N/A", "N/A"),
+  variableStartShortLabel = c("N/A", "height", "weight"),
+  notes = c("", "", "")
+)
+DT::datatable(variable_details_sheet)
+```
+
+The first row of the sheet contains the details for recoding the derived
+variable BMI. Its `variableStart` column value uses the previous notation
+but has a 35 as its value for the `upper_bound` parameter, effectively
+truncating the upper end to 35.
+
+The `rec_with_table` code using this sheet is shown below,
+
+```{r}
+data <- data.frame(
+  weight = c(100, 1000),
+  height = c(5, 5)
+)
+recoded_BMI <- rec_with_table(
+  data = data,
+  variables = c("height", "weight", "BMI"),
+  variable_details = variable_details_sheet,
+  database_name = 'health',
+  log = TRUE
+)
+print(recoded_BMI$BMI)
+```
+
+Notice how the second value is truncated to the value of 35 instead of its
+normaly calculated value of 40.


### PR DESCRIPTION
This PR adds support for using string and numeric constant start variables for a derived variable. In addition,

# Bug Fixes

* Fixes a bug with table start variables where more than one table would crash the function

# Refactors

* Refactored all tests to use the new `setup_custom_function`