### PR TITLE
Validate databaseStart references in variableStart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,13 @@ and this project adheres to
 ### Added
 
 * Added a new utility function `get_start_variables` 
+* Added an `invalid_database_reference` validation to `parse_variables_sheet()`
+  that checks every database referenced in `variableStart` is declared in that
+  row's `databaseStart`.
+
+### Changed
+
+* `databaseStart` is now a required column on the variables sheet passed to
+  `parse_variables_sheet()`. Previously only `variable` and `variableStart`
+  were required; callers passing a sheet without `databaseStart` will now
+  receive a `missing_required_columns` error.

--- a/R/parse-variables-sheet.R
+++ b/R/parse-variables-sheet.R
@@ -20,7 +20,10 @@ parse_variables_sheet <- function(variables_sheet) {
     ))
   }
 
-  validation_errors <- .validate_derived_variables(variables_sheet)
+  validation_errors <- c(
+    .validate_derived_variables(variables_sheet),
+    .validate_database_references(variables_sheet)
+  )
   if (length(validation_errors) > 0) {
     return(list(
       success = FALSE,
@@ -46,7 +49,8 @@ parse_variables_sheet <- function(variables_sheet) {
 
   required_cols <- c(
     pkg.env$columns.variable,
-    pkg.env$columns.variableStart
+    pkg.env$columns.variableStart,
+    pkg.env$columns.databaseStart
   )
   variables_sheet_cols <- colnames(variables_sheet)
   required_cols_validation <- checkmate::test_names(
@@ -123,6 +127,39 @@ parse_variables_sheet <- function(variables_sheet) {
   ))
 }
 
+#' Create an invalid database reference error object
+#'
+#' @param row The row number in the variables sheet where the error occurred
+#' @param database The database name referenced in variableStart but not
+#' declared in databaseStart
+#' @param databases_in_start The list of databases declared in databaseStart
+#' for that row
+#'
+#' @return A list containing the error object with type, row, database,
+#' databases_in_start, and message fields
+#' @keywords internal
+.create_invalid_database_reference_error <- function(
+    row, database, databases_in_start) {
+  contents_msg <- if (length(databases_in_start) == 0) {
+    "databaseStart is empty"
+  } else {
+    paste0(
+      "databaseStart contains: ",
+      paste(databases_in_start, collapse = ", ")
+    )
+  }
+  return(list(
+    type = "invalid_database_reference",
+    row = row,
+    database = database,
+    databases_in_start = databases_in_start,
+    message = glue::glue(
+      "variableStart at row {row} references database '{database}' which ",
+      "is not declared in databaseStart. {contents_msg}"
+    )
+  ))
+}
+
 #' Validate the derived variables in a variables sheet
 #'
 #' @param variables_sheet A data frame containing the variables sheet
@@ -154,6 +191,92 @@ parse_variables_sheet <- function(variables_sheet) {
     purrr::compact() |>
     purrr::flatten()
   return(errors)
+}
+
+#' Validate that databases referenced in variableStart are declared in
+#' databaseStart for each row
+#'
+#' Database references inside `DerivedVar::[...]` blocks are ignored here
+#' since they are already caught by `.validate_derived_variables` as
+#' `invalid_dependency` errors. References checked include the top-level
+#' `db::col` form and the nested `db::[DerivedVar::[...]]` form.
+#'
+#' @param variables_sheet A data frame containing the variables sheet
+#'
+#' @return A list of errors (empty if no errors found)
+#' @keywords internal
+.validate_database_references <- function(variables_sheet) {
+  if (nrow(variables_sheet) == 0) {
+    return(list())
+  }
+
+  errors <- seq_len(nrow(variables_sheet)) |>
+    purrr::map(function(i) {
+      row <- variables_sheet[i, ]
+      variable_start <- row[[pkg.env$columns.variableStart]]
+      database_start <- row[[pkg.env$columns.databaseStart]]
+
+      referenced_dbs <- .extract_referenced_databases(variable_start)
+      if (length(referenced_dbs) == 0) {
+        return(NULL)
+      }
+
+      declared_dbs <- .parse_database_start(database_start)
+      missing_dbs <- referenced_dbs[!referenced_dbs %in% declared_dbs]
+
+      if (length(missing_dbs) == 0) {
+        return(NULL)
+      }
+
+      purrr::map(missing_dbs, function(db) {
+        .create_invalid_database_reference_error(i, db, declared_dbs)
+      })
+    }) |>
+    purrr::compact() |>
+    purrr::flatten()
+  return(errors)
+}
+
+#' Parse the databaseStart column value into a character vector of database
+#' names
+#'
+#' @param database_start The databaseStart string
+#'
+#' @return A character vector of database names (empty if NA or blank)
+#' @keywords internal
+.parse_database_start <- function(database_start) {
+  if (is.na(database_start) || nchar(trimws(database_start)) == 0) {
+    return(character(0))
+  }
+  return(trimws(strsplit(database_start, ",")[[1]]))
+}
+
+#' Extract database names referenced in a variableStart value, ignoring any
+#' references nested inside `DerivedVar::[...]` blocks
+#'
+#' @param variable_start The variableStart string
+#'
+#' @return A unique character vector of referenced database names
+#' @keywords internal
+.extract_referenced_databases <- function(variable_start) {
+  if (is.na(variable_start) || nchar(trimws(variable_start)) == 0) {
+    return(character(0))
+  }
+
+  # Strip DerivedVar::[...] blocks so refs inside them aren't counted; those
+  # are already covered by the invalid_dependency check.
+  derived_var_block_pattern <- paste0(
+    pkg.env$recode.key.derived.var, "\\[[^]]*\\]"
+  )
+  stripped <- gsub(derived_var_block_pattern, "", variable_start)
+
+  matches <- regmatches(stripped, gregexpr("\\w+::", stripped))[[1]]
+  if (length(matches) == 0) {
+    return(character(0))
+  }
+
+  dbs <- sub("::$", "", matches)
+  return(unique(dbs))
 }
 
 #' Extract start variables from a variableStart column value

--- a/tests/testthat/test-parse-variables-sheet.R
+++ b/tests/testthat/test-parse-variables-sheet.R
@@ -2,6 +2,7 @@ test_that("Should return the parsed variables sheet when there are non-derived
           variables using database variables", {
   vars_sheet <- data.frame(
     variable = c("age", "sex", "height"),
+    databaseStart = c("cchs2001_p", "cchs2001_p", "cchs2001_p"),
     variableStart = c(
       "[age]", "cchs2001_p::sex", "[height], cchs2001_p::height"
     )
@@ -19,6 +20,7 @@ test_that("Should return the parsed variables sheet when there are derived
           variables using non-derived variables", {
   vars_sheet <- data.frame(
     variable = c("height", "weight", "BMI"),
+    databaseStart = c("db1", "db1", "db1"),
     variableStart = c("[height]", "[weight]", "DerivedVar::[height, weight]")
   )
 
@@ -34,6 +36,7 @@ test_that("Should return the parsed variables sheet when there are derived
           variables using other derived variables", {
   vars_sheet <- data.frame(
     variable = c("age", "height", "weight", "BMI", "BMI_x_age"),
+    databaseStart = c("db1", "db1", "db1", "db1", "db1"),
     variableStart = c(
       "[age]", "height", "weight", "DerivedVar::[height, weight]",
       "DerivedVar::[BMI, age]"
@@ -60,6 +63,7 @@ test_that("Should return errors when there are derived variables using
       "height", "BMI", "DrinkerType", "freq_cig", "SmokerType",
       "Empty"
     ),
+    databaseStart = rep("cchs2001_p", 6),
     variableStart = c(
       "[height]", "DerivedVar::[height, cchs2001_p::weight]",
       "DerivedVar::[cchs2001_p::freq_drinks]", "[freq_cig]",
@@ -84,13 +88,15 @@ test_that("Should return errors when there are derived variables using
 test_that("Should return errors when the variableStart column is missing from
           the variables sheet", {
   vars_sheet <- data.frame(
-    variable = c("age", "sex")
+    variable = c("age", "sex"),
+    databaseStart = c("db1", "db1")
   )
 
   expected_result <- list(
     success = FALSE,
     errors = list(
-      .create_missing_required_columns_error(c("variableStart"), c("variable"))
+      .create_missing_required_columns_error(
+        c("variableStart"), c("variable", "databaseStart"))
     )
   )
   actual_result <- parse_variables_sheet(vars_sheet)
@@ -101,13 +107,35 @@ test_that("Should return errors when the variableStart column is missing from
 test_that("Should return errors when the variable column is missing from the
           variables sheet", {
   vars_sheet <- data.frame(
+    variableStart = c("[age]", "[sex]"),
+    databaseStart = c("db1", "db1")
+  )
+
+  expected_result <- list(
+    success = FALSE,
+    errors = list(
+      .create_missing_required_columns_error(
+        c("variable"), c("variableStart", "databaseStart"))
+    )
+  )
+
+  actual_result <- parse_variables_sheet(vars_sheet)
+
+  expect_equal(actual_result, expected_result)
+})
+
+test_that("Should return errors when the databaseStart column is missing from
+          the variables sheet", {
+  vars_sheet <- data.frame(
+    variable = c("age", "sex"),
     variableStart = c("[age]", "[sex]")
   )
 
   expected_result <- list(
     success = FALSE,
     errors = list(
-      .create_missing_required_columns_error(c("variable"), c("variableStart"))
+      .create_missing_required_columns_error(
+        c("databaseStart"), c("variable", "variableStart"))
     )
   )
 
@@ -119,6 +147,7 @@ test_that("Should return errors when the variable column is missing from the
 test_that("Should not fail when the variable sheet has no rows", {
   vars_sheet <- data.frame(
     variable = character(0),
+    databaseStart = character(0),
     variableStart = character(0)
   )
 
@@ -163,6 +192,133 @@ test_that("Should return an error when the variables sheet is not a data frame",
   )
   actual_result4 <- parse_variables_sheet(numeric_input)
   expect_equal(actual_result4, expected_result4)
+})
+
+test_that("Should return errors when variableStart references a database not
+          declared in databaseStart", {
+  vars_sheet <- data.frame(
+    variable = c("age", "sex"),
+    databaseStart = c("cchs2001_p", "cchs2001_p"),
+    variableStart = c("[age]", "cchs2003_p::sex")
+  )
+
+  expected_result <- list(
+    success = FALSE,
+    errors = list(
+      .create_invalid_database_reference_error(2, "cchs2003_p", "cchs2001_p")
+    )
+  )
+
+  actual_result <- parse_variables_sheet(vars_sheet)
+
+  expect_equal(actual_result, expected_result)
+})
+
+test_that("Should return one error per missing database when multiple
+          undeclared databases are referenced", {
+  vars_sheet <- data.frame(
+    variable = c("sex"),
+    databaseStart = c("cchs2001_p"),
+    variableStart = c("cchs2003_p::sex, cchs2005_p::sex")
+  )
+
+  expected_result <- list(
+    success = FALSE,
+    errors = list(
+      .create_invalid_database_reference_error(1, "cchs2003_p", "cchs2001_p"),
+      .create_invalid_database_reference_error(1, "cchs2005_p", "cchs2001_p")
+    )
+  )
+
+  actual_result <- parse_variables_sheet(vars_sheet)
+
+  expect_equal(actual_result, expected_result)
+})
+
+test_that("Should pass when databaseStart lists multiple databases and
+          variableStart references a subset", {
+  vars_sheet <- data.frame(
+    variable = c("sex"),
+    databaseStart = c("cchs2001_p, cchs2003_p, cchs2005_p"),
+    variableStart = c("cchs2003_p::sex, cchs2005_p::sex")
+  )
+
+  expected_result <- data.frame(vars_sheet)
+  class(expected_result) <- c("variables_sheet", "data.frame")
+
+  actual_result <- parse_variables_sheet(vars_sheet)
+
+  expect_equal(actual_result, expected_result)
+})
+
+test_that("Should return errors when databaseStart is NA but variableStart
+          contains database references", {
+  vars_sheet <- data.frame(
+    variable = c("age"),
+    databaseStart = NA_character_,
+    variableStart = c("cchs2001_p::age")
+  )
+
+  expected_result <- list(
+    success = FALSE,
+    errors = list(
+      .create_invalid_database_reference_error(
+        1, "cchs2001_p", character(0))
+    )
+  )
+
+  actual_result <- parse_variables_sheet(vars_sheet)
+
+  expect_equal(actual_result, expected_result)
+})
+
+test_that("Should validate databases referenced via the
+          db::[DerivedVar::[...]] nested form", {
+  vars_sheet <- data.frame(
+    variable = c("RACDPAL"),
+    databaseStart = c("cchs2003_p"),
+    variableStart = c(
+      paste0(
+        "cchs2001_p::[DerivedVar::[RAC_1, RAC_2A]], ",
+        "cchs2003_p::RACCDPAL"
+      )
+    )
+  )
+
+  expected_result <- list(
+    success = FALSE,
+    errors = list(
+      .create_invalid_database_reference_error(1, "cchs2001_p", "cchs2003_p")
+    )
+  )
+
+  actual_result <- parse_variables_sheet(vars_sheet)
+
+  expect_equal(actual_result, expected_result)
+})
+
+test_that("Should not flag database references that appear inside a
+          DerivedVar::[...] block (those are caught by invalid_dependency)", {
+  # Row 1 has a derived var that references a database column inline and also
+  # references a database that is not declared in databaseStart. Only the
+  # invalid_dependency error should be raised; no invalid_database_reference
+  # error should be raised for the undeclared database.
+  vars_sheet <- data.frame(
+    variable = c("BMI"),
+    databaseStart = c("cchs2001_p"),
+    variableStart = c("DerivedVar::[height, cchs2003_p::weight]")
+  )
+
+  expected_result <- list(
+    success = FALSE,
+    errors = list(
+      .create_invalid_dependency_error(1, "cchs2003_p::weight")
+    )
+  )
+
+  actual_result <- parse_variables_sheet(vars_sheet)
+
+  expect_equal(actual_result, expected_result)
 })
 
 test_that("Integration test with PBC variables sheet", {


### PR DESCRIPTION
Add a new validation step to parse_variables_sheet that checks each row's variableStart for database::column references and ensures the database is declared in that row's databaseStart. databaseStart is now a required column, and the new check covers both the top-level db::col form and the nested db::[DerivedVar::[...]] form.